### PR TITLE
fix: .dockerignoreからconfig.pyを削除してDockerイメージに含めるように修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,9 +30,6 @@ test_*.py
 # ログファイル
 *.log
 
-# 環境設定（本番環境では別途設定）
-config.py
-
 # その他
 .DS_Store
 README.md


### PR DESCRIPTION
## 概要

Fly.ioデプロイ時に`ModuleNotFoundError: No module named 'config'`エラーが発生していた問題を修正しました。

## 問題

`.dockerignore`に`config.py`が含まれていたため、Dockerイメージビルド時に`config.py`が除外され、アプリケーション起動時にインポートエラーが発生していました。

## 修正内容

- `.dockerignore`から`config.py`の除外を削除
- `config.py`がDockerイメージに含まれるようになり、本番環境でも環境変数から設定を読み込めるように

## テスト

- Fly.ioでの再デプロイ後、アプリケーションが正常に起動することを確認予定

## 変更ファイル

- `.dockerignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)