### PR TITLE
fix: .gitignoreからconfig.pyを削除してリポジトリに含めるように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-config.py
 __pycache__
 *.json
 *.db
@@ -6,3 +5,4 @@ venv/*
 
 # ただしrequirements.txtは含める
 !requirements.txt
+# config.pyは本番環境用のため含める

--- a/config.py
+++ b/config.py
@@ -1,0 +1,23 @@
+# 本番環境用設定ファイル
+# 環境変数から設定を読み込みます
+
+import os
+
+# Webサーバーの待ち受けポート
+PORT = int(os.environ.get('PORT', 8888))
+
+# デバッグモードで起動するか (本番環境ではFalse)
+DEBUG = os.environ.get('DEBUG', 'False').lower() in ['true', '1', 'yes']
+
+# MeCabで使用する辞書があるディレクトリの絶対パス
+MECAB_DICDIR = os.environ.get('MECAB_DICDIR', None)
+
+# mecabrcの絶対パス
+MECAB_RC = os.environ.get('MECAB_RC', None)
+
+# Sentry DSN (エラー監視用、オプション)
+SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
+
+# セッションキー (本番環境では環境変数から読み取る)
+# fly secrets set SECRET_KEY=your-secret-key-here で設定してください
+SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key-change-in-production-12345')


### PR DESCRIPTION
config.pyがGitで管理されていなかったため、Fly.ioのビルド時にconfig.pyが含まれず ModuleNotFoundErrorが発生していた。本番環境用の設定ファイルとしてリポジトリに含める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)