### PR TITLE
fix: マシン数を1台に制限してjob_status共有問題を解決

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,13 @@ primary_region = 'nrt'
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
+  max_machines_running = 1
+
+[[http_service.concurrency]]
+  type = "requests"
+  hard_limit = 250
+  soft_limit = 200
 
 [[http_service.checks]]
   grace_period = "10s"


### PR DESCRIPTION
job_statusはメモリ上のグローバル辞書のため、複数マシン間で共有されない。
また、ボリュームは1台のマシンにしかマウントできないため、マシン数を1台に制限。

変更内容：
- min_machines_running = 1（常に1台稼働）
- max_machines_running = 1（最大1台に制限）
- concurrency設定を追加（リクエスト同時処理数の制限）

🤖 Generated with [Claude Code](https://claude.com/claude-code)